### PR TITLE
✨ [Feat] 세션 저장소로 Redis 사용

### DIFF
--- a/src/main/java/dongguk/osori/config/RedisConfig.java
+++ b/src/main/java/dongguk/osori/config/RedisConfig.java
@@ -1,0 +1,29 @@
+package dongguk.osori.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+@Configuration
+@EnableRedisHttpSession
+public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory("localhost", 6379);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer()); // Key를 String으로 직렬화
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer()); // Value를 JSON으로 직렬화
+        return template;
+    }
+}

--- a/src/main/java/dongguk/osori/domain/user/UserController.java
+++ b/src/main/java/dongguk/osori/domain/user/UserController.java
@@ -72,5 +72,4 @@ public class UserController {
     }
 
 
-
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,6 @@
 spring.datasource.url=jdbc:mysql://localhost:3306/osori
 spring.datasource.username=toni
 spring.datasource.password=1234
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # JPA
 spring.jpa.hibernate.ddl-auto=update
@@ -12,17 +11,16 @@ spring.jpa.properties.hibernate.format_sql=true
 
 # Session
 spring.session.store-type=redis
-spring.session.redis.namespace=osori:session
-
+spring.session.timeout=1800s
 
 # Redis
-spring.redis.host=redis
+spring.redis.host=localhost
 spring.redis.port=6379
 spring.redis.password=1234
 
 # Session Cookie Configuration
 server.servlet.session.cookie.name=JSESSIONID
-# server.servlet.session.timeout=30m
-# server.servlet.session.cookie.secure=true
-# server.servlet.session.cookie.http-only=true
-
+# HTTPS ?? ? true? ??
+server.servlet.session.cookie.secure=false
+server.servlet.session.cookie.http-only=true
+server.servlet.session.timeout=30m


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
기본 HttpSession에서, 세션 저장소를 Redis로 변경


## 작업사항
1) RedisConfig
2) application.properties


## 변경로직
1) RedisConfig
- `@EnableRedisHttpSession`: Redis를 사용한 HttpSession 저장소 사용
- `LettuceConnectionFactory`: Redis 연결 정보 설정 (현재 localhost로 되어있고 이후 변경 필요)
- `StringRedisSerializer()` & `GenericJackson2JsonRedisSerializer()`: Key를 String으로 직렬화, Value를 JSON으로 직렬화
- `redis-cli`, `keys *` 또는 `KEYS spring:session*`로 세션 확인

2) application.properties
- 이후 비밀번호 환경변수 처리 필요
- `server.servlet.session.cookie.secure=false`: 이후 HTTPS 적용하며 true로 변경
- session timeout 30분으로 설정해둠